### PR TITLE
enable dummy_for_hcc_ on host path as well

### DIFF
--- a/cub/util_type.cuh
+++ b/cub/util_type.cuh
@@ -244,13 +244,10 @@ struct RemoveQualifiers<Tp, const volatile Up>
  * Marker types
  ******************************************************************************/
 
-/**
- * \brief A simple "NULL" marker type
- */
 struct NullType
 {
 #ifndef DOXYGEN_SHOULD_SKIP_THIS    // Do not document
-    #if defined(__HIP_DEVICE_COMPILE__)
+    #if defined(__HIP_PLATFORM_HCC__)
         int dummy_for_hcc_;
     #endif
     template <typename T>


### PR DESCRIPTION
This PR can fix the following error message: 
../cub/block/specializations/../../block/block_radix_sort.cuh:497:18: error: variables in AMP-restricted function shall be 4-bytes aligned
        NullType values[ITEMS_PER_THREAD];