### PR TITLE
Correct warp shuffle / reduce logic to remove hardcoded warp size

### DIFF
--- a/cub/util_ptx.cuh
+++ b/cub/util_ptx.cuh
@@ -472,7 +472,7 @@ unsigned int WarpId()
 {
     unsigned int ret;
     int Tid = (hipBlockIdx_x * hipBlockDim_x * hipBlockDim_y) + (hipThreadIdx_y * hipBlockDim_x) + hipThreadIdx_x;
-    ret =  Tid / 32;
+    ret =  Tid / warpSize;
 
     return ret;
 }
@@ -486,7 +486,7 @@ unsigned int LaneMaskLt()
 {
     unsigned int ret;
     unsigned int Tid = hipBlockIdx_x * hipBlockDim_x * hipBlockDim_y + hipThreadIdx_y * hipBlockDim_x + hipThreadIdx_x;
-    unsigned int lane = Tid % 32;
+    unsigned int lane = Tid % warpSize;
     ret = (1 << lane) - 1;
 
     return ret;
@@ -501,7 +501,7 @@ unsigned int LaneMaskLe()
 {
     unsigned int ret;
     unsigned int Tid = hipBlockIdx_x * hipBlockDim_x * hipBlockDim_y + hipThreadIdx_y * hipBlockDim_x + hipThreadIdx_x;
-    unsigned int lane = Tid % 32;
+    unsigned int lane = Tid % warpSize;
     ret = (2 << lane) - 1;
 
     return ret;
@@ -543,6 +543,21 @@ unsigned long long LaneMaskGe()
 
 /** @} */       // end group UtilPtx
 
+
+
+
+#ifdef __HIP_PLATFORM_HCC__
+     typedef unsigned long mask_type;
+#else
+     typedef unsigned int mask_type;
+#endif
+/**
+ *  Return a default execution mask (all warp lanes enabled) with correct size for the HIP platform in use
+ */
+__device__ __forceinline__ mask_type DefaultMask()
+{
+	return ((mask_type)-1);
+}
 
 
 

--- a/cub/util_ptx.cuh
+++ b/cub/util_ptx.cuh
@@ -544,23 +544,6 @@ unsigned long long LaneMaskGe()
 /** @} */       // end group UtilPtx
 
 
-
-
-#ifdef __HIP_PLATFORM_HCC__
-     typedef unsigned long mask_type;
-#else
-     typedef unsigned int mask_type;
-#endif
-/**
- *  Return a default execution mask (all warp lanes enabled) with correct size for the HIP platform in use
- */
-__device__ __forceinline__ mask_type DefaultMask()
-{
-	return ((mask_type)-1);
-}
-
-
-
 /**
  * \brief Shuffle-up for any data type.  Each <em>warp-lane<sub>i</sub></em> obtains the value \p input contributed by <em>warp-lane</em><sub><em>i</em>-<tt>src_offset</tt></sub>.  For thread lanes \e i < src_offset, the thread's own \p input is returned to the thread. ![](shfl_up_logo.png)
  * \ingroup WarpModule

--- a/cub/warp/specializations/warp_default_mask.cuh
+++ b/cub/warp/specializations/warp_default_mask.cuh
@@ -1,0 +1,28 @@
+/**
+ * \file
+ * cub::DefaultMask provides HIP shuffle-mask compatibility to warp shuffle operators
+ */
+
+
+#pragma once
+/// Optional outer namespace(s)
+CUB_NS_PREFIX
+
+/// CUB namespace
+namespace cub {
+
+#ifdef __HIP_PLATFORM_HCC__
+     typedef unsigned long mask_type;
+#else
+     typedef unsigned int mask_type;
+#endif
+/**
+ *  Return a default execution mask (all warp lanes enabled) with correct size for the HIP platform in use
+ */
+__device__ __forceinline__ mask_type DefaultMask()
+{
+	return ((mask_type)-1);
+}
+
+}               // CUB namespace
+CUB_NS_POSTFIX  // Optional outer namespace(s)

--- a/cub/warp/specializations/warp_reduce_shfl.cuh
+++ b/cub/warp/specializations/warp_reduce_shfl.cuh
@@ -38,6 +38,7 @@
 #include "../../util_type.cuh"
 #include "../../util_macro.cuh"
 #include "../../util_namespace.cuh"
+#include "warp_default_mask.cuh"
 
 /// Optional outer namespace(s)
 CUB_NS_PREFIX

--- a/cub/warp/specializations/warp_reduce_shfl.cuh
+++ b/cub/warp/specializations/warp_reduce_shfl.cuh
@@ -142,8 +142,8 @@ struct WarpReduceShfl
         lane_id(LaneId()),
 
         member_mask(IS_ARCH_WARP ?
-             0xffffffff :
-             (0xffffffff >> (32 - LOGICAL_WARP_THREADS)) << (LaneId() / LOGICAL_WARP_THREADS))
+             DefaultMask() :
+             (DefaultMask() >> (warpSize - LOGICAL_WARP_THREADS)) << (LaneId() / LOGICAL_WARP_THREADS))
     {}
 
 

--- a/cub/warp/specializations/warp_reduce_smem.cuh
+++ b/cub/warp/specializations/warp_reduce_smem.cuh
@@ -38,7 +38,7 @@
 #include "../../thread/thread_store.cuh"
 #include "../../util_type.cuh"
 #include "../../util_namespace.cuh"
-#include "../../util_ptx.cuh"
+#include "warp_default_mask.cuh"
 
 /// Optional outer namespace(s)
 CUB_NS_PREFIX

--- a/cub/warp/specializations/warp_reduce_smem.cuh
+++ b/cub/warp/specializations/warp_reduce_smem.cuh
@@ -38,6 +38,7 @@
 #include "../../thread/thread_store.cuh"
 #include "../../util_type.cuh"
 #include "../../util_namespace.cuh"
+#include "../../util_ptx.cuh"
 
 /// Optional outer namespace(s)
 CUB_NS_PREFIX
@@ -117,8 +118,8 @@ struct WarpReduceSmem
             LaneId() :
             LaneId() % LOGICAL_WARP_THREADS),
         member_mask(!IS_POW_OF_TWO ?
-            (0xffffffff >> (64 - LOGICAL_WARP_THREADS)) :                                       // non-power-of-two subwarps cannot be tiled
-            (0xffffffff >> (64 - LOGICAL_WARP_THREADS)) << (LaneId() / LOGICAL_WARP_THREADS))
+            (DefaultMask() >> (warpSize - LOGICAL_WARP_THREADS)) :                                       // non-power-of-two subwarps cannot be tiled
+            (DefaultMask() >> (warpSize - LOGICAL_WARP_THREADS)) << (LaneId() / LOGICAL_WARP_THREADS))
     {}
 
     /******************************************************************************
@@ -229,7 +230,7 @@ struct WarpReduceSmem
         #endif
 
         // Clip the next segment at the warp boundary if necessary
-        if (LOGICAL_WARP_THREADS != 32)
+        if (LOGICAL_WARP_THREADS != warpSize)
             next_flag = CUB_MIN(next_flag, LOGICAL_WARP_THREADS);
 
         #pragma unroll

--- a/cub/warp/specializations/warp_scan_shfl.cuh
+++ b/cub/warp/specializations/warp_scan_shfl.cuh
@@ -37,6 +37,7 @@
 #include "../../util_type.cuh"
 #include "../../util_ptx.cuh"
 #include "../../util_namespace.cuh"
+#include "warp_default_mask.cuh"
 
 /// Optional outer namespace(s)
 CUB_NS_PREFIX

--- a/cub/warp/specializations/warp_scan_shfl.cuh
+++ b/cub/warp/specializations/warp_scan_shfl.cuh
@@ -102,7 +102,7 @@ struct WarpScanShfl
     :
         lane_id(LaneId()),
 
-        member_mask((0xffffffff >> (32 - LOGICAL_WARP_THREADS)) << ((IS_ARCH_WARP) ?
+        member_mask((DefaultMask() >> (warpSize - LOGICAL_WARP_THREADS)) << ((IS_ARCH_WARP) ?
             0 : // arch-width subwarps need not be tiled within the arch-warp
             ((lane_id / LOGICAL_WARP_THREADS) * LOGICAL_WARP_THREADS)))
     {}

--- a/cub/warp/specializations/warp_scan_smem.cuh
+++ b/cub/warp/specializations/warp_scan_smem.cuh
@@ -38,6 +38,7 @@
 #include "../../thread/thread_store.cuh"
 #include "../../util_type.cuh"
 #include "../../util_namespace.cuh"
+#include "../../util_ptx.cuh"
 
 /// Optional outer namespace(s)
 CUB_NS_PREFIX
@@ -108,8 +109,8 @@ struct WarpScanSmem
             LaneId() :
             LaneId() % LOGICAL_WARP_THREADS),
         member_mask(!IS_POW_OF_TWO ?
-            (0xffffffff >> (32 - LOGICAL_WARP_THREADS)) :                                       // non-power-of-two subwarps cannot be tiled
-            (0xffffffff >> (32 - LOGICAL_WARP_THREADS)) << (LaneId() / LOGICAL_WARP_THREADS))
+            (DefaultMask() >> (warpSize - LOGICAL_WARP_THREADS)) :                                       // non-power-of-two subwarps cannot be tiled
+            (DefaultMask() >> (warpSize - LOGICAL_WARP_THREADS)) << (LaneId() / LOGICAL_WARP_THREADS))
     {}
 
 

--- a/cub/warp/specializations/warp_scan_smem.cuh
+++ b/cub/warp/specializations/warp_scan_smem.cuh
@@ -38,7 +38,7 @@
 #include "../../thread/thread_store.cuh"
 #include "../../util_type.cuh"
 #include "../../util_namespace.cuh"
-#include "../../util_ptx.cuh"
+#include "warp_default_mask.cuh"
 
 /// Optional outer namespace(s)
 CUB_NS_PREFIX


### PR DESCRIPTION
Hello,

I was compiling a code that uses the HIP-port of CUB, and I ran into several compile time warnings of the form:

```
cub-hip/cub/block/specializations/../../warp/specializations/warp_scan_smem.cuh:112:25: warning: shift count is negative [-Wshift-count-negative]
            (0xffffffff >> (32 - LOGICAL_WARP_THREADS)) << (LaneId() / LOGICAL_WARP_THREADS))
                        ^  ~~~~~~~~~~~~~~~~~~~~~~~~~~~
.rootdir/cub-hip/cub/warp/warp_scan.cuh:622:26: note: in instantiation of member function 'cub::WarpScanSmem<int, 64, 520>::WarpScanSmem' requested here
        InternalWarpScan internal(temp_storage);
                         ^
.rootdir/cub-hip/cub/warp/warp_scan.cuh:363:9: note: in instantiation of function template specialization 'cub::WarpScan<int, 64, 520>::ExclusiveScan<cub::Sum>' requested here
        ExclusiveScan(input, exclusive_output, initial_value, cub::Sum());
```

Seemingly this is due to the hard-coded execution mask and warp size corresponding to NVIDIA cards.

The attached is a fix for these compile warnings.  The patched code seems to fix the `test_warp_reduce` test on my system (Sapphire VII, ROCm 2.4).

I've attached a log of the build / test process using (e.g.,):

```
make all -j64 quicktest=1 > unpatched_build.log 2>&1
make run quicktest=1 > unpatched_test.log 2>&1
```

for review for both the patched and unpatched cases.

Let me know if there are any additional fixes / changes.

Thanks,

Nick

